### PR TITLE
[Automated] Standardize Ballerina.toml keywords

### DIFF
--- a/build-config/resources/Ballerina.toml
+++ b/build-config/resources/Ballerina.toml
@@ -5,7 +5,7 @@ name = "ibm.ctg"
 version = "@toml.version@"
 license= ["Apache-2.0"]
 authors = ["Ballerina"]
-keywords = ["IBM", "CICS", "CTG", "Mainframe"]
+keywords = ["IBM", "CICS", "CTG", "Mainframe", "Vendor/IBM", "Area/Other", "Type/Other"]
 icon = "icon.png"
 repository = "https://github.com/ballerina-platform/module-ballerinax-ibm.ctg"
 

--- a/build-config/resources/Ballerina.toml
+++ b/build-config/resources/Ballerina.toml
@@ -5,7 +5,7 @@ name = "ibm.ctg"
 version = "@toml.version@"
 license= ["Apache-2.0"]
 authors = ["Ballerina"]
-keywords = ["IBM", "CICS", "CTG", "Mainframe", "Vendor/IBM", "Area/Other", "Type/Other"]
+keywords = ["IBM", "CICS", "CTG", "Mainframe", "Vendor/IBM", "Area/Integration", "Type/Connector"]
 icon = "icon.png"
 repository = "https://github.com/ballerina-platform/module-ballerinax-ibm.ctg"
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This pull request standardizes the package keywords in the Ballerina.toml configuration file to improve discoverability and categorization of the IBM CICS Transaction Gateway connector module.

## Changes

The keywords array in the `[package]` section of `build-config/resources/Ballerina.toml` has been extended with three standardized classification keywords:
- `Vendor/IBM` - identifies the vendor
- `Area/Integration` - categorizes the integration area
- `Type/Connector` - identifies the package type

These additions complement the existing keywords (IBM, CICS, CTG, Mainframe) and provide better organization and searchability for package discovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->